### PR TITLE
fix: prevent showing 100% before contest end

### DIFF
--- a/src/views/Contest/Contest.vue
+++ b/src/views/Contest/Contest.vue
@@ -30,9 +30,9 @@ let loading = $ref(false)
 
 const timePercentage = $computed(() => {
   if (currentTime < contest.start) return 0
-  if (currentTime > contest.end) return 100
-  return +((currentTime - contest.start) * 100
-    / (contest.end - contest.start)).toFixed(1)
+  if (currentTime >= contest.end) return 100
+  const percentage=(currentTime-contest.start)*100/(contest.end-contest.start)
+  return Math.floor(percentage*10)/10
 })
 const progressStatus = $computed(() => {
   if (timePercentage === 100) return 'success'


### PR DESCRIPTION
防止在比赛结束前，进度条因四舍五入显示100%
- `timePercentage` 的计算方式改为下取整
- 结束的判定改为`if (currentTime >= contest.end)`

由于是一个比较简单的fix，所以没有在本地测试